### PR TITLE
Add rpi camera support

### DIFF
--- a/app/routes/cameras.js
+++ b/app/routes/cameras.js
@@ -31,9 +31,15 @@ module.exports = (platform) => {
     
       for(const camera of platform.cameras){
     
-        let protocol = camera.videoConfig.source.split('-i ')[1].split('://')[0] + '://';
-  
-        let host = camera.videoConfig.source.split(protocol)[1];
+        let source = camera.videoConfig.source.split('-i ')[1].split(' ')[0];
+        
+        if (source.startsWith('/dev/video')) {
+          // TODO add device checking
+          camera.ping = true;
+          continue;
+        }
+
+        let host = source.split('://')[1];
 
         if(host.includes('@')){
 


### PR DESCRIPTION
It's small fix for usb or rpi camera module.
If you have one of that you should use configuration like [this](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki/Tested-Configurations#Pi-Camera-V2)
```
"videoConfig": {
  "source": "... -i /dev/video0",
  ...
}
```
but if you add this source you'll get error like this #18.