### PR TITLE
fixed wrong path selection in MQTT

### DIFF
--- a/src/helper/handler.js
+++ b/src/helper/handler.js
@@ -48,7 +48,8 @@ class Handler {
         active = path[1] != 'reset';  
       }
       
-      switch (path[0]) {
+      // switch over last element in path array
+      switch (path[path.length-1]) {
         case 'motion':
           Logger.debug('Motion event triggered.');
           return this.motionHandler(accessory, active);


### PR DESCRIPTION
### This fixed the wrong Path in the Switch case, when the first value in the fullpath is not "Homebridge"

switch over last element in path array
--> e.g. /service/homebridge/motion
--> `path = ["service", "motion"]`
-->` path[path.length-1] == motion` and not service with `path[0]`

**Note:** "Homebridge" was removed, due to filter statement in line 43 ` value !== 'homebridge'`