### PR TITLE
Only record dummy track if config has audioEnabled=true

### DIFF
--- a/src/services/recording.service.js
+++ b/src/services/recording.service.js
@@ -64,17 +64,6 @@ export default class RecordingDelegate {
     let incompatibleAudio = audioSourceFound && !probeAudio.some((codec) => compatibleAudio.test(codec));
     //let probeTimedOut = controller?.media.codecs.timedout;
 
-    if (!audioSourceFound) {
-      this.log.debug(
-        'Replacing audio with a dummy track, audio source not found or timed out during probe stream (recording)',
-        this.accessory.displayName,
-        'Homebridge'
-      );
-
-      ffmpegInput.push('-f', 'lavfi', '-i', 'anullsrc=cl=1', '-shortest');
-      audioEnabled = true;
-    }
-
     if (audioEnabled) {
       if (audioSourceFound) {
         if (incompatibleAudio && acodec !== 'libfdk_aac') {
@@ -90,6 +79,14 @@ export default class RecordingDelegate {
           acodec = 'copy';
         }
       } else {
+        this.log.debug(
+          'Replacing audio with a dummy track, audio source not found or timed out during probe stream (recording)',
+          this.accessory.displayName,
+          'Homebridge'
+        );
+
+        ffmpegInput.push('-f', 'lavfi', '-i', 'anullsrc=cl=1', '-shortest');
+
         acodec = 'libfdk_aac';
       }
 


### PR DESCRIPTION
If the user has explicitly set audioEnabled=false in the config, I don't think it makes sense to record a dummy track if audio is not detected in the stream. This should fix that. It also fixes #359 without having to install a new ffmpeg.