### PR TITLE
Fix ffmpeg log level

### DIFF
--- a/src/accessories/camera.js
+++ b/src/accessories/camera.js
@@ -573,7 +573,7 @@ export default class CameraDelegate {
       const ffmpegArguments = [
         '-hide_banner',
         '-loglevel',
-        `level${videoConfig.debug ? '+verbose' : ''}`,
+        videoConfig.debug ? 'verbose' : 'error',
         ...ffmpegInput,
       ];
 
@@ -719,7 +719,7 @@ export default class CameraDelegate {
         const ffmpegReturnArguments = [
           '-hide_banner',
           '-loglevel',
-          videoConfig.debug ? '+verbose' : '',
+          videoConfig.debug ? 'verbose' : '',
           '-protocol_whitelist',
           'pipe,udp,rtp,file,crypto',
           '-f',


### PR DESCRIPTION
This may only be an issue with the `ffmpeg` version I'm running, but I don't see what adding the string `level` to the log level does. It crashes my version of `ffmpeg`. It fixes #451 

This PR changes the log level to `verbose` when debug logging is on and `error` otherwise. It may be that this is incompatible with the version of `ffmpeg` that ships with this package, in which case there may need to be another solution.