### PR TITLE
ffmpeg profile use id instead of name

### DIFF
--- a/src/services/recording.service.js
+++ b/src/services/recording.service.js
@@ -162,10 +162,10 @@ export default class RecordingDelegate {
 
     const profile =
       this.configuration.videoCodec.profile === this.api.hap.H264Profile.HIGH
-        ? 'high'
+        ? '100'
         : this.configuration.videoCodec.profile === this.api.hap.H264Profile.MAIN
-        ? 'main'
-        : 'baseline';
+        ? '77'
+        : '66';
 
     const level =
       this.configuration.videoCodec.level === this.api.hap.H264Level.LEVEL4_0


### PR DESCRIPTION
I'm getting `ERROR  CAM1: FFmpeg recording process exited with error! (null)`
I'm using RPi 4 with encoder h264_v4l2m2m

Digging into it I see `-profile:v baseline` is the cause, and I see that https://ffmpeg.org/ffmpeg-codecs.html#Codec-Options says profile should be integer, and `baseline` should be `66`, and `main` should be `77` from https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/avcodec.h#L1608 

- OS: Ubuntu aarch64
- Software: Homebridge v1.5.0 (HAP v0.10.2)
- Node: v16.17.0
- npm: 8.15.0

```
[9/14/2022, 2:58:27 PM] [CameraUI] CAM1: Recording command: /var/lib/homebridge/node_modules/homebridge-camera-ui/node_modules/ffmpeg-for-homebridge/ffmpeg -hide_banner -i rtsp://1.1.1.1:554/?inst=2 -f mp4 -sn -dn -vcodec h264_v4l2m2m -pix_fmt yuv420p -profile:v baseline -level:v 3.1 -b:v 2000k -vf framerate=fps=25*1000/1001,scale=w=1920:h=1080:force_original_aspect_ratio=1,pad=1920:1080:(ow-iw)/2:(oh-ih)/2 -force_key_frames expr:gte(t,n_forced*4) -an -movflags frag_keyframe+empty_moov+default_base_moof -max_muxing_queue_size 1024 tcp://127.0.0.1:37505
```

```
[9/14/2022, 2:58:28 PM] [CameraUI] CAM1: [h264_v4l2m2m @ 0xaaaabedda180] [Eval @ 0xffffed254208] Undefined constant or missing '(' in 'baseline'
[9/14/2022, 2:58:28 PM] [CameraUI] CAM1: [h264_v4l2m2m @ 0xaaaabedda180] Unable to parse option value "baseline"
[9/14/2022, 2:58:28 PM] [CameraUI] CAM1: [h264_v4l2m2m @ 0xaaaabedda180] Error setting option profile to value baseline.
[9/14/2022, 2:58:28 PM] [CameraUI] CAM1: Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
```

